### PR TITLE
 correct length in movie-info during "stop"

### DIFF
--- a/src/gui/movieplayer.cpp
+++ b/src/gui/movieplayer.cpp
@@ -2561,6 +2561,9 @@ void CMoviePlayerGui::handleMovieBrowser(neutrino_msg_t msg, int /*position*/)
 			p_movie_info->dateOfLastPlay = current_time.time;
 			current_time.time = time(NULL);
 			p_movie_info->bookmarks.lastPlayStop = position / 1000;
+			if (p_movie_info->length == 0) {
+				p_movie_info->length = (float)duration / 60 / 1000 + 0.5;
+			}
 			cMovieInfo.saveMovieInfo(*p_movie_info);
 			//p_movie_info->fileInfoStale(); //TODO: we might to tell the Moviebrowser that the movie info has changed, but this could cause long reload times  when reentering the Moviebrowser
 		}


### PR DESCRIPTION
This will correct/set the length of the video, if it is "0". This is typical the case, if an video is played without XML description file. In this case the file is created by movieplayer, but up to now the length is not set. With the change, the length will be set during "stop" so it is available for further use.