### PR TITLE
moviebrowser: re-introduce parameter "paint_hdd" in info_hdd_level()

### DIFF
--- a/src/gui/moviebrowser/mb.cpp
+++ b/src/gui/moviebrowser/mb.cpp
@@ -1554,7 +1554,7 @@ void CMovieBrowser::refreshDetailsLine(int pos)
 	}
 }
 
-void CMovieBrowser::info_hdd_level(bool /* paint_hdd */)
+void CMovieBrowser::info_hdd_level(bool paint_hdd)
 {
 	if (show_mode == MB_SHOW_YT)
 		return;
@@ -1573,7 +1573,7 @@ void CMovieBrowser::info_hdd_level(bool /* paint_hdd */)
 	if (tmp_blocks_percent_used != blocks_percent_used || paint_hdd) {
 		tmp_blocks_percent_used = blocks_percent_used;
 */
-	if (g_settings.infobar_show_sysfs_hdd) {
+	if (g_settings.infobar_show_sysfs_hdd && paint_hdd) {
 		const short pbw = 100;
 		const short border = m_cBoxFrameTitleRel.iHeight/4;
 		CProgressBar pb(m_cBoxFrame.iX+ m_cBoxFrameFootRel.iWidth - m_header->getContextBtnObject()->getWidth() - pbw - border, m_cBoxFrame.iY+m_cBoxFrameTitleRel.iY + border, pbw, m_cBoxFrameTitleRel.iHeight/2);


### PR DESCRIPTION
... because member "m_header" may not be initialized when method is called by updateMovieSelection()

m_header will be initialized inside of refreshTitle(), but is used also in info_hdd_level(). paint() calls refreshTitle() but info_hdd_level() may be called before inside of loadMovies() / refreshBrowserList() / updateMovieSelection() depending on some conditions. This will cause a nullpointer and an crash (at least on my system). The change avoids the use of m_header if info_hdd_level() is called by updateMovieSelection(), as it was some time before.